### PR TITLE
README.md: Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $loader->registerNamespaces(array(
 $reader = new \ePub\Reader();
 $epub = $reader->load('my-book.epub');
 
-printf("Title: %s\n", $epub->getMetadata()->get('title'));
+printf("Title: %s\n", $epub->getMetadata()->getValue('title'));
 ```
 
 


### PR DESCRIPTION
`get` returns an array of `ePub\Definition\MetadataItem` objects, causing an Array to String error when using the printf example.

`getValue` returns a string, which allows the printf to successfully print the title of the loaded epub.